### PR TITLE
Make relation text editable

### DIFF
--- a/src/Box.java
+++ b/src/Box.java
@@ -4,9 +4,9 @@ import javafx.scene.layout.VBox;
 
 public class Box extends VBox {
 	Controller controller;
-	Section[] sections = new Section[4];
-	Double coordX;
-	Double coordY;
+	private Section[] sections = {new Section(this, "add class name", true), new Section(this, "add attribute", false), new Section(this, "add operation", false), new Section(this, "add miscellaneous", false)};
+	private Double offsetX;
+	private Double offsetY;
 
 	public Box(Controller c) {
 		controller = c;
@@ -15,21 +15,14 @@ public class Box extends VBox {
 		Box thisBox = this;
 		setPrefWidth(141);
 		
-		sections[0] = new Section(this, "add class name", true);
-		sections[1] = new Section(this, "add attribute", false);
-		sections[2] = new Section(this, "add operation", false);
-		sections[3] = new Section(this, "add miscellaneous", false);
-		
 		getChildren().addAll(sections[0], sections[1], sections[2], sections[3]);
 		
 		setOnMouseDragged(new EventHandler<MouseEvent>() {
 			@Override
 			public void handle(MouseEvent event) {
-				//css style to show grid while rectangle is being dragged - should be call to controller like below on setOnMouseReleased
-				controller.workspace.getStyleClass().remove("noGrid");
-				controller.workspace.getStyleClass().add("grid");
-				double x = event.getSceneX() - coordX;
-				double y = event.getSceneY() - coordY;
+				controller.showGrid();
+				double x = event.getSceneX() - offsetX;
+				double y = event.getSceneY() - offsetY;
 				//round to nearest 20 px
 				relocate(Math.floorDiv((int) x, 20) * 20, Math.floorDiv((int) y, 20) * 20);
 				controller.updateRelations();
@@ -39,15 +32,15 @@ public class Box extends VBox {
 		setOnMousePressed(new EventHandler<MouseEvent>() {
 			@Override
 			public void handle(MouseEvent event) {
-				coordX = event.getSceneX() - getLayoutX();
-				coordY = event.getSceneY() - getLayoutY();
+				offsetX = event.getSceneX() - getLayoutX();
+				offsetY = event.getSceneY() - getLayoutY();
 			}
 		});
 		
 		setOnMouseReleased(new EventHandler<MouseEvent>(){
 			@Override
 			public void handle(MouseEvent arg0) {
-				controller.showGrid();
+				controller.hideGrid();
 			}
 		});
 		
@@ -58,7 +51,7 @@ public class Box extends VBox {
 				if (controller.isAddingRelation()) {
 					controller.endCurrentRelation(thisBox);
 				}
-				else if (thisBox != controller.selectedBox) {
+				else if (thisBox != controller.getSelectedBox()) {
 					controller.deselectBox();
 					controller.selectBox(thisBox);
 				}
@@ -67,6 +60,7 @@ public class Box extends VBox {
 			}
 		});
 		
+		//created box starts selected
 		controller.selectBox(this);
 	}
 	
@@ -74,7 +68,7 @@ public class Box extends VBox {
 		boolean okayToHide = true;
 		for (int i = 3; i >= 1; --i){
 			sections[i].deselect();
-			if (okayToHide && !sections[i].isTitle && sections[i].isEmpty()) {
+			if (okayToHide && sections[i].isEmpty()) {
 				getChildren().remove(sections[i]);
 			}
 			else {

--- a/src/Controller.java
+++ b/src/Controller.java
@@ -9,7 +9,7 @@ public class Controller {
 	FileMenu menu;
 	WorkSpace workspace;
 	BorderPane ui;
-	Box selectedBox = null;
+	private Box selectedBox = null;
 	private Relation currentRelation = null;
 	private boolean addingRelation = false;
 	private Relation selectedRelation;
@@ -93,8 +93,13 @@ public class Controller {
 		
 	}
 	
-	public void showGrid() {
+	public void hideGrid() {
 		workspace.getStyleClass().add("noGrid");
+	}
+	
+	public void showGrid() {
+		workspace.getStyleClass().remove("noGrid");
+		workspace.getStyleClass().add("grid");
 	}
 	
 	public void startNewRelation() {
@@ -154,5 +159,9 @@ public class Controller {
 		for (Relation r : relations) {
 			r.update();
 		}
+	}
+	
+	public Box getSelectedBox() {
+		return selectedBox;
 	}
 }

--- a/src/Input.java
+++ b/src/Input.java
@@ -2,40 +2,52 @@ import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
 import javafx.scene.control.TextField;
 
-public class Input extends TextField{
-	
-	final Section parent;
-	
+public class Input extends TextField {
+
+	Section section;
+	Relation relation;
+
 	public Input(Section p, String s) {
+
+		section = p;
 		
-		parent = p;
-		
-		Input thisInput = this;
-		
-		//set input text to previous value unless it is the prompt text
+		// set input text to previous value unless it is the prompt text
 		if (!s.equals(p.prompt)) {
 			setText(s);
 		}
-		
-		//hit enter in input, lose focus
-		setOnAction(new EventHandler<ActionEvent>() {
-			@Override
-			public void handle(ActionEvent e) {
-				thisInput.setFocused(false);
-			}
-		});
-		
-		//on lost focus, process input
+
+		loseFocus();
+
+		// on lost focus, process input
 		focusedProperty().addListener((observable, oldvalue, newvalue) -> {
-			if (newvalue == false){
-				parent.processInput(this);
+			if (newvalue == false) {
+				section.processInput(this);
 			}
 		});
+
+	}
+
+	public Input(Relation r) {
+		relation = r;
 		
+		loseFocus();
+
+		// on lost focus, process input
+		focusedProperty().addListener((observable, oldvalue, newvalue) -> {
+			if (newvalue == false) {
+				relation.processInput();
+			}
+		});
 	}
 	
-	public Input() {
-		parent = null;
+	// hit enter in input, lose focus
+	public void loseFocus() {
+			setOnAction(new EventHandler<ActionEvent>() {
+				@Override
+				public void handle(ActionEvent e) {
+					setFocused(false);
+				}
+			});
 	}
 
 }

--- a/src/Relation.java
+++ b/src/Relation.java
@@ -9,7 +9,8 @@ public class Relation extends Line {
 	private Box startBox = null;
 	private Box endBox = null;
 	private Controller controller;
-	private Input text;
+	private TextLine text;
+	private Input input = new Input(this);
 	
 	//relation types
 	final int GENERALIZATION = 0;
@@ -36,7 +37,7 @@ public class Relation extends Line {
 			}
 		});
 		
-		text = new Input();
+		text = new TextLine("add text here", this);
 		
 		arrowHead = new ImageView();
 	}
@@ -65,11 +66,12 @@ public class Relation extends Line {
 	
 	public void addText() {
 		controller.workspace.getChildren().add(text);
-		text.layoutXProperty().bind(startXProperty().add(endXProperty().subtract(text.widthProperty())).divide(2));
-		text.layoutYProperty().bind(startYProperty().add(endYProperty().subtract(text.heightProperty().multiply(2))).divide(2));
+		
+		text.layoutXProperty().bind(startXProperty().add(endXProperty().subtract(text.xProperty())).divide(2));
+		text.layoutYProperty().bind(startYProperty().add(endYProperty().subtract(text.yProperty().multiply(2))).divide(2));
 	}
 	
-	public Input getText() {
+	public TextLine getText() {
 		return text;
 	}
 	
@@ -162,4 +164,22 @@ public class Relation extends Line {
 		}
 		return angle;
 	}
+	
+	public void addInput(String s) {
+		input.setText(s);
+		controller.workspace.getChildren().remove(text);
+		controller.workspace.getChildren().add(input);
+		
+		input.layoutXProperty().bind(startXProperty().add(endXProperty().subtract(input.widthProperty())).divide(2));
+		input.layoutYProperty().bind(startYProperty().add(endYProperty().subtract(input.heightProperty().multiply(2))).divide(2));
+
+		input.requestFocus();
+	}
+	
+	public void processInput() {
+		text.setText(input.getText());
+		addText();
+		controller.workspace.getChildren().remove(input);
+	}
+
 }

--- a/src/TextLine.java
+++ b/src/TextLine.java
@@ -5,20 +5,44 @@ import javafx.scene.text.Text;
 public class TextLine extends Text {
 
 	Section parent;
+	Relation relation;
 
 	public TextLine(String s, Section p) {
-		
 		super(s);
+		
 		parent = p;
 		TextLine thisLine = this;
+		
+		//keeps box width from expanding
+		setWrappingWidth(141);
 
 		setOnMouseClicked(new EventHandler<MouseEvent>() {
 			@Override
 			public void handle(MouseEvent event) {
-				p.addInput(thisLine.getText(), thisLine);
+				if (parent.parent.controller.getSelectedBox() == parent.parent) {
+					p.addInput(thisLine.getText(), thisLine);
+				}
 			}
 		});
 
 	}
+	
+	public TextLine(String s, Relation r) {
+		super(s);
+		
+		parent = null;
+		relation = r;
+		
+		TextLine thisLine = this;
+		
+		setOnMouseClicked(new EventHandler<MouseEvent>() {
+			@Override
+			public void handle(MouseEvent event) {
+					relation.addInput(thisLine.getText());
+					event.consume();
+			}
+		});
+	}
+
 
 }


### PR DESCRIPTION
-Text on relation lines is now editable when clicked on
-Saves input similar to class box text
-Set text wrapping width on class boxes so their width stays static
-Fixed class box selection bug where two inputs are added with one click