### PR TITLE
Fix to arrowheads incorrectly positioning

### DIFF
--- a/src/Box.java
+++ b/src/Box.java
@@ -1,3 +1,5 @@
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
 import javafx.event.EventHandler;
 import javafx.scene.Node;
 import javafx.scene.input.MouseEvent;
@@ -95,6 +97,22 @@ public class Box extends VBox {
 		//created box starts selected
 		controller.addBox(this);
 		controller.selectBox(this);
+		
+		//listener to update relations when height of box is changed
+		heightProperty().addListener(new ChangeListener<Object>(){
+			@Override
+			public void changed(ObservableValue<? extends Object> observable, Object oldValue, Object newValue) {
+				controller.updateRelations();
+			}
+	    });
+		
+		//listener to update relations when width of box is changed
+		widthProperty().addListener(new ChangeListener<Object>(){
+			@Override
+			public void changed(ObservableValue<? extends Object> observable, Object oldValue, Object newValue) {
+				controller.updateRelations();
+			}
+	    });
 	}
 	
 	/**

--- a/src/ContextMenu.java
+++ b/src/ContextMenu.java
@@ -195,13 +195,7 @@ public class ContextMenu extends VBox {
 			getChildren().add(singleRelation);
 		}
 	}
-	public void showRelationTypeButtons(){
-                getChildren().add(aggregation);
-                getChildren().add(composition);
-                getChildren().add(association);
-                getChildren().add(generalization);
-        }
-        
+    
 	/**
 	 * Hides the appropriate edit relation button
 	 */
@@ -210,16 +204,21 @@ public class ContextMenu extends VBox {
 		getChildren().remove(singleRelation);
 		getChildren().remove(doubleRelation);
 	}
-        
-        public void hideRelationTypeButtons(){
-                getChildren().remove(aggregation);
-                getChildren().remove(composition);
-                getChildren().remove(association);
-                getChildren().remove(generalization);
-        }
-        
-        
 	
+	public void showRelationTypeButtons(){
+        getChildren().add(aggregation);
+        getChildren().add(composition);
+        getChildren().add(association);
+        getChildren().add(generalization);
+    }
+	
+    public void hideRelationTypeButtons(){
+        getChildren().remove(aggregation);
+        getChildren().remove(composition);
+        getChildren().remove(association);
+        getChildren().remove(generalization);
+    }
+    
 	/**
 	 * applies a shadow or removes a shadow from the addRelation button
 	 * @param b - boolean for whether a shadow should be applied or removed

--- a/src/Controller.java
+++ b/src/Controller.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Scanner;
 import java.util.Set;
+
 import javafx.print.PrinterJob;
 import javafx.scene.Node;
 import javafx.scene.layout.BorderPane;
@@ -227,9 +228,9 @@ public class Controller {
 			selectedRelation.setStroke(Color.WHITE);
 			toolbar.hideAddBoxButton();
 			toolbar.hideAddRelationButton();
+			toolbar.showRelationTypeButtons();
 			toolbar.showEditRelationButtons();
 			toolbar.showDeleteButton();
-                        toolbar.showRelationTypeButtons();
 			selectedRelation.showText();
 		} else if (selectedRelation != relation) {
 			selectedRelation.setStroke(null);

--- a/src/Relation.java
+++ b/src/Relation.java
@@ -162,8 +162,6 @@ public class Relation extends Line {
 	
 	/**
 	 * arrow heads are to be properly positioned and rotated
-	 * Currently arrow heads can become incorrectly positioned when boxes collapse and expand
-	 * Currently dragging an attached box or clicking in the workspace, sets the arrow heads to the correct position
 	 */
 	public void update() {
 		updateArrowPosition(arrowHead, startBox, endBox);
@@ -239,7 +237,6 @@ public class Relation extends Line {
 	
 	/**
 	 * Arrow heads are set based on type of relation desired
-	 * Currently only contains implementation for generalization
 	 * secondArrowHead is updated if the relation is double ended
 	 * @param relationType - determines type of arrow head
 	 */
@@ -248,20 +245,20 @@ public class Relation extends Line {
 		if (relationType == GENERALIZATION) {
 			arrowHead.setImage(new Image("/ui elements/gen.png", false));
 		}
-                if (relationType == ASSOCIATION) {
+		if (relationType == ASSOCIATION) {
 			arrowHead.setImage(new Image("/ui elements/assoc.png", false));
 		}
-                if (relationType == AGGREGATION) {
+		if (relationType == AGGREGATION) {
 			arrowHead.setImage(new Image("/ui elements/agg.png", false));
 		}
-                if (relationType == COMPOSITION) {
+		if (relationType == COMPOSITION) {
 			arrowHead.setImage(new Image("/ui elements/comp.png", false));
 		}
-		//...
 		
 		if (!isSingleEnded()) {
 			secondArrowHead.setImage(arrowHead.getImage());
 		}
+		update();
 	}
 	
 	/**
@@ -314,7 +311,7 @@ public class Relation extends Line {
 		update();
 	}
 	
-	/*
+	/**
 	 * remove secondArrowHead
 	 */
 	public void setSingleEnded() {

--- a/src/WorkSpace.java
+++ b/src/WorkSpace.java
@@ -30,8 +30,6 @@ public class WorkSpace extends Pane{
 				workspace.requestFocus();
 				controller.deselectRelation();
 				controller.deselectBox();
-				//Temporary: clicking in workspace will fix all mispositioned arrowheads
-				controller.updateRelations();
 				controller.toolbar.setAddRelationShadow(false);
 			}
 		});


### PR DESCRIPTION
-arrow heads are correctly positioned when boxes change width or height
-buttons for relation editing were switching order (fixed now)